### PR TITLE
doc: fix typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 CoreAPI is a high-performance RSGI lightweight framework for building API's in python with no requirements
 
 #### RSGI?
-> RSGI i a Rust HTTP server interface for Python
+> RSGI is a Rust HTTP server interface for Python
 
 **Features**:
 - **RSGI Compliance:** The framework is designed to be RSGI compliant insuring better performance over ASGI.


### PR DESCRIPTION
This fixes a typo I spotted in the readme